### PR TITLE
Small import errors for audio fixed

### DIFF
--- a/packages/app/src/pages/Settings/Overview/Overview.tsx
+++ b/packages/app/src/pages/Settings/Overview/Overview.tsx
@@ -39,7 +39,7 @@ export const Overview: React.FC = ({}) => {
           setShouldShowTutorial(true);
           Preferences.set({
             key: "shouldShowSettingsTutorial",
-            value: "false",
+            value: false,
           });
         }
       });


### PR DESCRIPTION
- `Overview.tsx`
     - Value was set as a string when it should be a boolean (not sure if it was meant to be a boolean, but that is the error that TS was giving so I changed it to a boolean)
- `IntruderGame.tsx`
    - Changed .mp3 imports to .wav to reflect new normalized audio files
- `IntruderIntro.tsx`
    - Changed .mp3 imports to .wav to reflect new normalized audio files
- `IntruderCongrats.tsx`
    - Changed .mp3 imports to .wav to reflect new normalized audio files