### PR TITLE
enabled next button on intro pages

### DIFF
--- a/packages/app/src/components/Intro/Intro.tsx
+++ b/packages/app/src/components/Intro/Intro.tsx
@@ -101,7 +101,6 @@ export const Intro: React.FC<IntroProps> = ({ texts, image, nextPath }) => {
               <IonButton
                 onClick={() => history.push(nextPath)}
 		className='margin-top-3'
-		disabled={!audioPlayed}
                 shape="round"
 		expand='block'
                 style={{width: '50%', margin: 'auto'}}>


### PR DESCRIPTION
removed "disabled={!audioPlayed}" on line 104

enables next button immediately