### PR TITLE
increased padding at the bottom of the page wrapper

### DIFF
--- a/packages/app/src/pages/StudentDashboard.tsx
+++ b/packages/app/src/pages/StudentDashboard.tsx
@@ -255,7 +255,7 @@ export const StudentDashboard: FC = () => {
   ];
 
   return (
-    <div id="student-landing-page">
+    <div id="student-landing-page" style={{paddingBottom: "33vh"}}>
       <div
         className="cards-title background-pattern"
         style={{


### PR DESCRIPTION
added 'style={{paddingBottom: "33vh"}}'

increased the space between the comunidad story cards and the bottom of the page wrapper
