### PR TITLE
Sasha t dshb add students update

### DIFF
--- a/packages/app/src/components/AddStudentRow/AddStudentRow.scss
+++ b/packages/app/src/components/AddStudentRow/AddStudentRow.scss
@@ -2,8 +2,6 @@
   .add-student-row {
     border-radius: 14px;
     padding: 0px 16px;
-    // align-items: center;
-    // margin-top: 4px;
   }
 
   .even-row {
@@ -14,6 +12,12 @@
     background-color: rgba(247, 250, 249, 1);
   }
 
+  .save-student-data-button,
+  .cancel-student-data-button {
+    height: 56px;
+    width: 58px;
+  }
+
   .student-row-delete-button ion-icon {
     font-size: 23px;
   }
@@ -22,27 +26,10 @@
     font-size: 53px;
   }
 
-  .save-student-data-button {
-    padding: 18px 15px;
-    color: white;
-    border-radius: 8px;
-    background: #006a67;
-    display: flex;
-    gap: 4px;
-  }
-
   .edit-student-data {
     margin-top: 4px;
   }
 
-  .edit-student-data-button {
-    padding: 17px 8px;
-    display: flex;
-    border-radius: 8px;
-    border: 1px solid var(--Base-Selva, #006a67);
-    background: #e0edec;
-    gap: 4px;
-  }
   .student-row-edit-button,
   .student-row-delete-button {
     background: none;

--- a/packages/app/src/components/AddStudentRow/AddStudentRow.tsx
+++ b/packages/app/src/components/AddStudentRow/AddStudentRow.tsx
@@ -89,24 +89,25 @@ export const AddStudentRow: React.FC<RowProps> = ({
                 />
               </IonCol>
               <IonCol className="ion-no-padding" size={"auto"}>
-                <button
+                <IonButton
                   type="submit"
                   className="save-student-data-button text-sm semibold"
                 >
                   Save
-                </button>
+                </IonButton>
               </IonCol>
               <IonCol className="ion-no-padding" size={"auto"}>
-                <button
+                <IonButton
+                  color="secondary"
                   type="button"
-                  className="edit-student-data-button text-sm semibold"
+                  className="cancel-student-data-button text-sm semibold"
                   onClick={() => {
                     setIsEditing(null);
                     onEditingStatusChange(false);
                   }}
                 >
                   Cancel
-                </button>
+                </IonButton>
               </IonCol>
             </IonRow>
           </form>

--- a/packages/app/src/components/AddStudents/AddStudents.scss
+++ b/packages/app/src/components/AddStudents/AddStudents.scss
@@ -29,7 +29,7 @@
 .reset-student-button,
 .add-student-button {
   height: 56px;
-  width: 60px;
+  width: 58px;
 }
 
 .upload-csv-button {

--- a/packages/app/src/components/AddStudents/AddStudents.tsx
+++ b/packages/app/src/components/AddStudents/AddStudents.tsx
@@ -105,6 +105,7 @@ export const AddStudents: React.FC<AddStudentsProps> = ({
             <IonCol size="auto" className="reset-button-column ion-no-padding">
               <IonButton
                 className="reset-student-button text-sm semibold"
+                color="secondary"
                 type="button"
                 disabled={isEditing}
                 onClick={() => {

--- a/packages/app/src/components/ClassRoomComplete/ClassRoomComplete.css
+++ b/packages/app/src/components/ClassRoomComplete/ClassRoomComplete.css
@@ -8,4 +8,12 @@
   ion-button {
     width: 100%;
   }
+  ion-text {
+    max-width: 442px;
+  }
+
+  ion-img {
+    width: 337.25px;
+    height: 333px;
+  }
 }

--- a/packages/app/src/components/ClassRoomComplete/ClassRoomComplete.tsx
+++ b/packages/app/src/components/ClassRoomComplete/ClassRoomComplete.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { IonButton, IonCard, IonImg, IonText } from "@ionic/react";
+import "./ClassroomComplete.css";
+import { useHistory } from "react-router";
+
+interface ClassroomCompleteProps {
+  h2Text: string;
+  isDisabled: boolean;
+  path: string;
+}
+
+export const ClassroomComplete: React.FC<ClassroomCompleteProps> = ({
+  h2Text,
+  isDisabled,
+  path,
+}) => {
+  const history = useHistory();
+  return (
+    <div className="add-class-success">
+      <IonCard>
+        <IonText className="ion-text-center margin-bottom-3">
+          <h2 className="text-3xl semibold color-suelo">{h2Text}</h2>
+        </IonText>
+
+        <IonImg src="/assets/img/happy_cactus.png" />
+
+        <IonButton
+          className="margin-vertical-3"
+          data-testid="complete-continue-button"
+          disabled={isDisabled}
+          onClick={() => {
+            history.push(path);
+          }}
+          shape="round"
+        >
+          Continue
+        </IonButton>
+      </IonCard>
+    </div>
+  );
+};

--- a/packages/app/src/components/ClassRoomComplete/index.tsx
+++ b/packages/app/src/components/ClassRoomComplete/index.tsx
@@ -1,0 +1,1 @@
+export * from "./ClassRoomComplete";

--- a/packages/app/src/components/Router.tsx
+++ b/packages/app/src/components/Router.tsx
@@ -82,6 +82,7 @@ import {
 import { TeacherDashboardLayout } from "@/layouts/TeacherDashboard";
 import Reports from "@/pages/Reports";
 import { ClassStudents } from "@/pages/TeacherDashboard/ClassStudents";
+import { AddStudentsComplete } from "@/pages/TeacherDashboard/AddStudentsComplete";
 
 export const Router: React.FC = () => {
   const contentStyle: Record<string, string> = {};
@@ -406,10 +407,19 @@ export const Router: React.FC = () => {
                       />
                       <Route
                         exact
+                        path="/classrooms/view/:classroomId/add_students/notification-method"
+                        render={() => (
+                          <TeacherDashboardLayoutWithSideMenu>
+                            <AddClassroomNotificationMethod />
+                          </TeacherDashboardLayoutWithSideMenu>
+                        )}
+                      />
+                      <Route
+                        exact
                         path="/classrooms/view/:classroomId/add_students/complete"
                         render={() => (
                           <TeacherDashboardLayoutWithSideMenu>
-                            <ClassStudentsAddStudents />
+                            <AddStudentsComplete />
                           </TeacherDashboardLayoutWithSideMenu>
                         )}
                       />

--- a/packages/app/src/components/Router.tsx
+++ b/packages/app/src/components/Router.tsx
@@ -77,6 +77,7 @@ import {
   ClassOverview,
   MyClassrooms,
   StudentSelect,
+  ClassStudentsAddStudents,
 } from "@/pages/TeacherDashboard";
 import { TeacherDashboardLayout } from "@/layouts/TeacherDashboard";
 import Reports from "@/pages/Reports";
@@ -391,6 +392,15 @@ export const Router: React.FC = () => {
                         render={() => (
                           <TeacherDashboardLayoutWithSideMenu>
                             <ClassStudents />
+                          </TeacherDashboardLayoutWithSideMenu>
+                        )}
+                      />
+                      <Route
+                        exact
+                        path="/classrooms/view/:classroomId/add_students"
+                        render={() => (
+                          <TeacherDashboardLayoutWithSideMenu>
+                            <ClassStudentsAddStudents />
                           </TeacherDashboardLayoutWithSideMenu>
                         )}
                       />

--- a/packages/app/src/components/Router.tsx
+++ b/packages/app/src/components/Router.tsx
@@ -404,6 +404,15 @@ export const Router: React.FC = () => {
                           </TeacherDashboardLayoutWithSideMenu>
                         )}
                       />
+                      <Route
+                        exact
+                        path="/classrooms/view/:classroomId/add_students/complete"
+                        render={() => (
+                          <TeacherDashboardLayoutWithSideMenu>
+                            <ClassStudentsAddStudents />
+                          </TeacherDashboardLayoutWithSideMenu>
+                        )}
+                      />
                     </TeacherDashboardLayout>
                   </AdultCheckProvider>
                 </AuthedLayout>

--- a/packages/app/src/pages/TeacherDashboard/AddClassroom/AddClassroomComplete.css
+++ b/packages/app/src/pages/TeacherDashboard/AddClassroom/AddClassroomComplete.css
@@ -1,0 +1,11 @@
+.add-class-success {
+  display: flex;
+  justify-content: center;
+
+  ion-card {
+    align-items: center;
+  }
+  ion-button {
+    width: 100%;
+  }
+}

--- a/packages/app/src/pages/TeacherDashboard/AddClassroom/AddClassroomComplete.tsx
+++ b/packages/app/src/pages/TeacherDashboard/AddClassroom/AddClassroomComplete.tsx
@@ -1,7 +1,8 @@
-import { IonButton } from "@ionic/react";
+import { IonButton, IonCard, IonImg, IonText } from "@ionic/react";
 import { useAddClassroom } from "./AddClassroomContext";
 import { useEffect } from "react";
 import { useHistory } from "react-router-dom";
+import "./AddClassroomComplete.css";
 
 export const AddClassroomComplete: React.FC = () => {
   const { addClassroom, addClassroomStatus } = useAddClassroom();
@@ -15,17 +16,34 @@ export const AddClassroomComplete: React.FC = () => {
     return <>loading</>;
   } else {
     return (
-      <>
-        <IonButton
-          data-testid="complete-continue-button"
-          onClick={() => {
-            history.push("/classrooms");
-          }}
-          shape="round"
-        >
-          continue
-        </IonButton>
-      </>
+      <div className="add-class-success">
+        <IonCard>
+          <IonText className="ion-text-center margin-bottom-3">
+            <h2 className="text-3xl semibold color-suelo">
+              Success! You created your classroom!
+            </h2>
+          </IonText>
+
+          <IonImg
+            style={{
+              width: "337.25px",
+              height: "333px",
+            }}
+            src="/assets/img/happy_cactus.png"
+          />
+
+          <IonButton
+            className="margin-vertical-3"
+            data-testid="complete-continue-button"
+            onClick={() => {
+              history.push("/classrooms");
+            }}
+            shape="round"
+          >
+            Continue
+          </IonButton>
+        </IonCard>
+      </div>
     );
   }
 };

--- a/packages/app/src/pages/TeacherDashboard/AddClassroom/AddClassroomComplete.tsx
+++ b/packages/app/src/pages/TeacherDashboard/AddClassroom/AddClassroomComplete.tsx
@@ -2,7 +2,7 @@ import { IonButton, IonCard, IonImg, IonText } from "@ionic/react";
 import { useAddClassroom } from "./AddClassroomContext";
 import { useEffect } from "react";
 import { useHistory } from "react-router-dom";
-import "./AddClassroomComplete.css";
+import { ClassroomComplete } from "@/components/ClassRoomComplete";
 
 export const AddClassroomComplete: React.FC = () => {
   const { addClassroom, addClassroomStatus } = useAddClassroom();
@@ -13,37 +13,22 @@ export const AddClassroomComplete: React.FC = () => {
     }
   }, [addClassroomStatus]);
   if (addClassroomStatus !== "done") {
-    return <>loading</>;
-  } else {
+    //screen while loading data
     return (
-      <div className="add-class-success">
-        <IonCard>
-          <IonText className="ion-text-center margin-bottom-3">
-            <h2 className="text-3xl semibold color-suelo">
-              Success! You created your classroom!
-            </h2>
-          </IonText>
-
-          <IonImg
-            style={{
-              width: "337.25px",
-              height: "333px",
-            }}
-            src="/assets/img/happy_cactus.png"
-          />
-
-          <IonButton
-            className="margin-vertical-3"
-            data-testid="complete-continue-button"
-            onClick={() => {
-              history.push("/classrooms");
-            }}
-            shape="round"
-          >
-            Continue
-          </IonButton>
-        </IonCard>
-      </div>
+      <ClassroomComplete
+        h2Text={"Please wait while we create your class"}
+        isDisabled={true}
+        path={"/classrooms"}
+      />
+    );
+  } else {
+    //screen when the process is finished
+    return (
+      <ClassroomComplete
+        h2Text={"Success! You created your classroom!"}
+        isDisabled={false}
+        path={"/classrooms"}
+      />
     );
   }
 };

--- a/packages/app/src/pages/TeacherDashboard/AddClassroom/AddClassroomNotificationMethod.tsx
+++ b/packages/app/src/pages/TeacherDashboard/AddClassroom/AddClassroomNotificationMethod.tsx
@@ -18,14 +18,16 @@ import { FormattedMessage } from "react-intl";
 import { useForm } from "react-hook-form";
 import { RadioCard } from "@/components/RadioCard";
 import { ExtendedRadioOption, ExtendedRadio } from "@/components/ExtendedRadio";
-import { useHistory } from "react-router";
+import { useHistory, useParams } from "react-router";
 import "./AddClassroomCaregivers.css";
 
 import { useAddClassroom } from "./AddClassroomContext";
 
 export const AddClassroomNotificationMethod: React.FC = () => {
   const history = useHistory();
-  const { notificationMethod, setNotificationMethod } = useAddClassroom();
+  const { classroomId } = useParams<{ classroomId: string }>();
+  const { notificationMethod, setNotificationMethod, addClassroomStatus } =
+    useAddClassroom();
   const {
     control,
     formState: { isValid },
@@ -89,7 +91,11 @@ export const AddClassroomNotificationMethod: React.FC = () => {
 
   const onSubmit = handleSubmit((data) => {
     setNotificationMethod(data.notificationMethod);
-    history.push("/classrooms/add/complete");
+    if (addClassroomStatus !== "done") {
+      history.push("/classrooms/add/complete");
+    } else {
+      history.push(`/classrooms/view/:${classroomId}/add_students/complete`);
+    }
   });
 
   return (
@@ -98,11 +104,8 @@ export const AddClassroomNotificationMethod: React.FC = () => {
         <form className="radio-button-select">
           <IonText className="ion-text-center">
             <h3 className="text-3xl semibold color-suelo">
-              You’ve created your class!
-            </h3>
-            <p className="text-xl semibold color-suelo margin-top-2 invite-caregivers-text">
               Invite caregivers to download the app
-            </p>
+            </h3>
           </IonText>
           <ExtendedRadio
             control={control}

--- a/packages/app/src/pages/TeacherDashboard/AddClassroom/AddClassroomNotificationMethod.tsx
+++ b/packages/app/src/pages/TeacherDashboard/AddClassroom/AddClassroomNotificationMethod.tsx
@@ -20,21 +20,14 @@ import { RadioCard } from "@/components/RadioCard";
 import { ExtendedRadioOption, ExtendedRadio } from "@/components/ExtendedRadio";
 import { useHistory, useParams } from "react-router";
 import "./AddClassroomCaregivers.css";
-
 import { useAddClassroom } from "./AddClassroomContext";
+import { FirestoreDocProvider, useFirestoreDoc } from "@/hooks/FirestoreDoc";
 
 export const AddClassroomNotificationMethod: React.FC = () => {
   const history = useHistory();
   const { classroomId } = useParams<{ classroomId: string }>();
-  const { notificationMethod, setNotificationMethod, addClassroomStatus } =
-    useAddClassroom();
-  const {
-    control,
-    formState: { isValid },
-    handleSubmit,
-    setValue,
-    reset,
-  } = useForm({
+  const { notificationMethod, setNotificationMethod } = useAddClassroom();
+  const { control, handleSubmit } = useForm({
     defaultValues: {
       notificationMethod,
     },
@@ -90,11 +83,12 @@ export const AddClassroomNotificationMethod: React.FC = () => {
   };
 
   const onSubmit = handleSubmit((data) => {
-    setNotificationMethod(data.notificationMethod);
-    if (addClassroomStatus !== "done") {
-      history.push("/classrooms/add/complete");
+    if (classroomId) {
+      //should add differnt setNotificatioMethod for adding students
+      history.push(`/classrooms/view/${classroomId}/add_students/complete`);
     } else {
-      history.push(`/classrooms/view/:${classroomId}/add_students/complete`);
+      setNotificationMethod(data.notificationMethod);
+      history.push("/classrooms/add/complete");
     }
   });
 
@@ -115,7 +109,6 @@ export const AddClassroomNotificationMethod: React.FC = () => {
 
           <IonButton
             data-testid="addclassroom-notification-method-continue-button"
-            disabled={!isValid}
             shape="round"
             type="button"
             onClick={onSubmit}

--- a/packages/app/src/pages/TeacherDashboard/AddClassroom/AddClassroomNotificationMethod.tsx
+++ b/packages/app/src/pages/TeacherDashboard/AddClassroom/AddClassroomNotificationMethod.tsx
@@ -101,7 +101,7 @@ export const AddClassroomNotificationMethod: React.FC = () => {
               You’ve created your class!
             </h3>
             <p className="text-xl semibold color-suelo margin-top-2 invite-caregivers-text">
-              Invite student caregivers to download the app
+              Invite caregivers to download the app
             </p>
           </IonText>
           <ExtendedRadio

--- a/packages/app/src/pages/TeacherDashboard/AddClassroom/AddClassroomStudents.css
+++ b/packages/app/src/pages/TeacherDashboard/AddClassroom/AddClassroomStudents.css
@@ -3,22 +3,9 @@
     padding: 36px 0;
   }
 
-  .first-title-row {
-    padding: 16px 0;
-  }
-
   .add-and-upload-buttons {
     display: flex;
     gap: 24px;
-  }
-
-  .add-student-button {
-    padding: 4px 2px;
-    color: white;
-    border-radius: 8px;
-    background: #006a67;
-    display: flex;
-    gap: 4px;
   }
 
   .upload-csv-button {
@@ -31,35 +18,8 @@
     margin-left: 18px;
   }
 
-  .reset-student-button {
-    padding: 15px 12px;
-    color: white;
-    border-radius: 8px;
-    background: #006a67;
-    display: flex;
-    gap: 4px;
-  }
-
-  .reset-button-column {
-    text-align: -webkit-right;
-  }
-
-  .add-student-button ion-icon,
   .upload-csv-button ion-icon {
     font-size: 24px;
-  }
-
-  .add-student-button ion-icon {
-    margin-top: 8px;
-  }
-
-  .add-student-button p,
-  .upload-csv-button p {
-    margin-top: 3px;
-  }
-
-  .add-student-button p {
-    text-align: left;
   }
 
   .add-student-button-continue {

--- a/packages/app/src/pages/TeacherDashboard/AddClassroom/AddClassroomStudents.tsx
+++ b/packages/app/src/pages/TeacherDashboard/AddClassroom/AddClassroomStudents.tsx
@@ -25,8 +25,8 @@ import { useForm } from "react-hook-form";
 import { useHistory } from "react-router";
 import { FormattedMessage } from "react-intl";
 import { Student, useAddClassroom } from "./AddClassroomContext";
-
 import "./AddClassroomStudents.css";
+import { AddStudents } from "@/components/AddStudents";
 
 export const AddClassroomStudents: React.FC = () => {
   const history = useHistory();
@@ -72,82 +72,14 @@ export const AddClassroomStudents: React.FC = () => {
             Add your students
           </h3>
         </IonText>
-        <IonGrid className="add-students-grid">
-          {/* title row */}
-          <IonRow className="first-title-row text-md color-suelo semibold">
-            <IonCol size="2">Student first name</IonCol>
-            <IonCol size="2">Student last name</IonCol>
-            <IonCol size="3">Primary home contact email</IonCol>
-            <IonCol size="3">Secondary home contact email</IonCol>
-            <IonCol></IonCol>
-            <IonCol></IonCol>
-          </IonRow>
 
-          {/* rows with student data */}
-          <AddStudentRow
-            studentData={studentsData}
-            handleDeleteStudent={handleDeleteStudent}
-            handleEditStudentClick={handleEditStudentClick}
-            onEditingStatusChange={() => {
-              // TODO: what goes here?
-            }}
-          />
+        <AddStudents
+          studentsData={studentsData}
+          handleSaveStudentClick={handleSaveStudentClick}
+          handleEditStudentClick={handleEditStudentClick}
+          handleDeleteStudent={handleDeleteStudent}
+        />
 
-          {/* row for inputting student data */}
-
-          <form onSubmit={handleSubmit(handleSaveStudentClick)}>
-            <IonRow className="text-sm color-suelo">
-              <IonCol size="2">
-                <Input
-                  placeholder="First name"
-                  control={control}
-                  name="firstName"
-                />
-              </IonCol>
-              <IonCol size="2">
-                <Input
-                  placeholder="Last name"
-                  control={control}
-                  name="lastName"
-                />
-              </IonCol>
-              <IonCol size="3">
-                <Input
-                  placeholder="Primary email"
-                  control={control}
-                  name="primaryEmail"
-                />
-              </IonCol>
-              <IonCol size="3">
-                <Input
-                  placeholder="Secondary email"
-                  control={control}
-                  name="secondaryEmail"
-                />
-              </IonCol>
-              <IonCol size="1">
-                <button
-                  type="submit"
-                  className="add-student-button text-sm semibold"
-                >
-                  <IonIcon src={AddButton} />
-                  <p>Add student</p>
-                </button>
-              </IonCol>
-              <IonCol size="1" className="reset-button-column">
-                <button
-                  className="reset-student-button text-sm semibold"
-                  type="button"
-                  onClick={() => {
-                    reset();
-                  }}
-                >
-                  <p>Reset</p>
-                </button>
-              </IonCol>
-            </IonRow>
-          </form>
-        </IonGrid>
         <div className="add-and-upload-buttons">
           {/* TEMPORARY Hidden Button For .CSV files */}
           {/* <button className="upload-csv-button text-sm semibold color-selva">

--- a/packages/app/src/pages/TeacherDashboard/AddStudentsComplete.tsx
+++ b/packages/app/src/pages/TeacherDashboard/AddStudentsComplete.tsx
@@ -6,8 +6,9 @@ import { ClassroomComplete } from "@/components/ClassRoomComplete";
 export const AddStudentsComplete: React.FC = () => {
   const history = useHistory();
   const { classroomId } = useParams<{ classroomId: string }>();
+  // TODO: make a logic to show different screens:
+  //  loading screen vs loading is finished
 
-  //screen when the process is finished
   return (
     <ClassroomComplete
       h2Text={"Success! You added your students!"}

--- a/packages/app/src/pages/TeacherDashboard/AddStudentsComplete.tsx
+++ b/packages/app/src/pages/TeacherDashboard/AddStudentsComplete.tsx
@@ -1,0 +1,18 @@
+import { IonButton, IonCard, IonImg, IonText } from "@ionic/react";
+import { useEffect } from "react";
+import { useHistory, useParams } from "react-router-dom";
+import { ClassroomComplete } from "@/components/ClassRoomComplete";
+
+export const AddStudentsComplete: React.FC = () => {
+  const history = useHistory();
+  const { classroomId } = useParams<{ classroomId: string }>();
+
+  //screen when the process is finished
+  return (
+    <ClassroomComplete
+      h2Text={"Success! You added your students!"}
+      isDisabled={false}
+      path={`/classrooms/view/:${classroomId}/students`}
+    />
+  );
+};

--- a/packages/app/src/pages/TeacherDashboard/ClassStudents.tsx
+++ b/packages/app/src/pages/TeacherDashboard/ClassStudents.tsx
@@ -16,11 +16,12 @@ import {
 import { addOutline, addSharp } from "ionicons/icons";
 import ArrowRight from "@/assets/icons/arrow-right-grey.svg";
 import StudentsReadingPicture from "@/assets/img/kids_reading.png";
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { StudentInfo } from "@/components/StudentInfo";
 import "./ClassStudents.scss";
 
 export const ClassStudents: React.FC = () => {
+  const { classroomId } = useParams<{ classroomId: string }>();
   const studentsData = [
     {
       studentName: "John Doeeeeeee",
@@ -101,7 +102,7 @@ export const ClassStudents: React.FC = () => {
                 <button className="add-students-button">
                   <IonIcon icon={addSharp}></IonIcon>
                   <Link
-                    to={`/classrooms/view/:classroomId/add_students`}
+                    to={`/classrooms/view/${classroomId}/add_students`}
                     className="no-underline"
                   >
                     <p className="text-sm semibold color-nube">Add students</p>

--- a/packages/app/src/pages/TeacherDashboard/ClassStudents.tsx
+++ b/packages/app/src/pages/TeacherDashboard/ClassStudents.tsx
@@ -24,42 +24,42 @@ export const ClassStudents: React.FC = () => {
   const { classroomId } = useParams<{ classroomId: string }>();
   const studentsData = [
     {
-      studentName: "John Doeeeeeee",
+      id: "",
       primaryHomeEmail: "Michel Doeeeeee",
       secondaryHomeEmail: "john.doe@example.com",
       needsMoreSupport: "on track",
       homeAccount: "not active",
     },
     {
-      studentName: "John Doeeeeeee",
+      id: "",
       primaryHomeEmail: "Michel Doeeeeee",
       secondaryHomeEmail: "john.doe@example.com",
       needsMoreSupport: "support recommended",
       homeAccount: "active",
     },
     {
-      studentName: "John Doeeeeeee",
+      id: "",
       primaryHomeEmail: "Michel Doeeeeee",
       secondaryHomeEmail: "john.doe@example.com",
       needsMoreSupport: "on track",
       homeAccount: "not active",
     },
     {
-      studentName: "John Doeeeeeee",
+      id: "",
       primaryHomeEmail: "Michel Doeeeeee",
       secondaryHomeEmail: "john.doe@example.com",
       needsMoreSupport: "on track",
       homeAccount: "not active",
     },
     {
-      studentName: "John Doeeeeeee",
+      id: "",
       primaryHomeEmail: "Michel Doeeeeee",
       secondaryHomeEmail: "john.doe@example.com",
       needsMoreSupport: "support recommended",
       homeAccount: "not active",
     },
     {
-      studentName: "John Doeeeeeee",
+      id: "",
       primaryHomeEmail: "Michel Doeeeeee",
       secondaryHomeEmail: "john.doe@example.com",
       needsMoreSupport: "on track",
@@ -73,7 +73,7 @@ export const ClassStudents: React.FC = () => {
       homeAccount: "active",
     },
     {
-      studentName: "John Doeeeeeee",
+      id: "",
       primaryHomeEmail: "Michel Doeeeeee",
       secondaryHomeEmail: "john.doe@exampleeeeeeeeeeeee.com",
       needsMoreSupport: "on track",
@@ -118,8 +118,8 @@ export const ClassStudents: React.FC = () => {
         <IonGrid className="class-students-table-grid">
           <IonRow className="class-student-table-header-row">
             <IonCol className="text-md semibold">Student Name</IonCol>
-            <IonCol className="text-md semibold">Primary home email</IonCol>
-            <IonCol className="text-md semibold">Secondary home email</IonCol>
+            {/* <IonCol className="text-md semibold">Primary home email</IonCol>
+            <IonCol className="text-md semibold">Secondary home email</IonCol> */}
             <IonCol className="text-md semibold">Needs More Support</IonCol>
             <IonCol className="text-md semibold">Home Account</IonCol>
           </IonRow>
@@ -132,11 +132,11 @@ export const ClassStudents: React.FC = () => {
                 <StudentInfo
                   userId={""}
                   userType={""}
-                  link="/classrooms/add"
+                  link="http://localhost:5173/classrooms/view/:3GJTSWXuJ4NL3ZZpygF1/students/view/${studentId}"
                   size="xs"
                 />
               </IonCol>
-              <IonCol>
+              {/* <IonCol>
                 <IonText>
                   <p className="text-sm">
                     {student.primaryHomeEmail.length > 23
@@ -153,7 +153,7 @@ export const ClassStudents: React.FC = () => {
                       : student.secondaryHomeEmail}
                   </p>
                 </IonText>
-              </IonCol>
+              </IonCol> */}
               <IonCol>
                 <IonText
                   className="student-needs-support-text text-sm-xs semibold"
@@ -174,7 +174,15 @@ export const ClassStudents: React.FC = () => {
               </IonCol>
               <IonCol>
                 <IonText>
-                  <p className="text-sm">{student.homeAccount}</p>
+                  <p
+                    className={`text-sm ${
+                      student.homeAccount?.toLowerCase() === "not active"
+                        ? "semibold"
+                        : ""
+                    }`}
+                  >
+                    {student.homeAccount}
+                  </p>
                 </IonText>
               </IonCol>
             </IonRow>

--- a/packages/app/src/pages/TeacherDashboard/ClassStudents.tsx
+++ b/packages/app/src/pages/TeacherDashboard/ClassStudents.tsx
@@ -101,7 +101,7 @@ export const ClassStudents: React.FC = () => {
                 <button className="add-students-button">
                   <IonIcon icon={addSharp}></IonIcon>
                   <Link
-                    to={`/classrooms/:classroomId/add_students`}
+                    to={`/classrooms/view/:classroomId/add_students`}
                     className="no-underline"
                   >
                     <p className="text-sm semibold color-nube">Add students</p>

--- a/packages/app/src/pages/TeacherDashboard/ClassStudentsAddStudents.tsx
+++ b/packages/app/src/pages/TeacherDashboard/ClassStudentsAddStudents.tsx
@@ -18,7 +18,7 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { useSignUpData } from "../SignUp/SignUpContext";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useHistory } from "react-router";
+import { useHistory, useParams } from "react-router";
 import { firestore } from "@/components/Firebase";
 import { doc, updateDoc } from "firebase/firestore";
 import { useProfile } from "@/hooks/Profile";
@@ -36,6 +36,7 @@ interface Student {
 export const ClassStudentsAddStudents: React.FC = () => {
   const { data, setData, pushPage } = useSignUpData();
   const history = useHistory();
+  const { classroomId } = useParams<{ classroomId: string }>();
   const {
     user: { uid },
     profile: { isImmersive, isInclusive, settingsLanguage },
@@ -115,7 +116,9 @@ export const ClassStudentsAddStudents: React.FC = () => {
       </div>
 
       <div className="add-student-button-continue">
-        <IonRouterLink routerLink="/classrooms/add/notification-method">
+        <IonRouterLink
+          routerLink={`/classrooms/view/${classroomId}/add_students/notification-method`}
+        >
           <IonButton
             data-testid="add-student-continue-button"
             shape="round"

--- a/packages/app/src/pages/TeacherDashboard/ClassStudentsAddStudents.tsx
+++ b/packages/app/src/pages/TeacherDashboard/ClassStudentsAddStudents.tsx
@@ -115,7 +115,7 @@ export const ClassStudentsAddStudents: React.FC = () => {
       </div>
 
       <div className="add-student-button-continue">
-        <IonRouterLink routerLink="/classrooms/:classroomId/students">
+        <IonRouterLink routerLink="/classrooms/add/notification-method">
           <IonButton
             data-testid="add-student-continue-button"
             shape="round"


### PR DESCRIPTION
Updates were made to the Add students logic:
- Complete screens with cactus were added when the add students process is finished
- `AddStudentsComplete.tsx` and `AddClassroomComplete.tsx` have the same component     
<ClassroomComplete
        h2Text={""}
        isDisabled={}
        path={""}
      />
- `AddClassroomNotificationMethod.tsx` has the same logic for both creating a classroom and adding students, though different routes uses to call it : `path="/classrooms/add/notification-method"`  vs `path="/classrooms/view/:classroomId/add_students/notification-method"`
- Logic needs to be added for the `AddStudentsComplete.tsx` so students can be added to the already existed class
