### PR TITLE
cuentos text sizing update

### DIFF
--- a/packages/app/src/pages/Stories/KeyVocabPage.tsx
+++ b/packages/app/src/pages/Stories/KeyVocabPage.tsx
@@ -165,14 +165,14 @@ export const KeyVocabPage: React.FC<KeyVocabPage> = ({
         <IonCard className="drop-shadow story-page ion-no-padding">
           <IonCardContent>
             <IonText>
-              <h1 className="text-4xl text-semibold color-suelo ion-text-center">
+              <h1 className="text-4xl semibold color-suelo margin-top-1 ion-text-center">
                 <I18nMessage id="story.keyVocabulary.title" />
               </h1>
               <I18nMessage
                 id="story.keyVocabulary.title"
                 level={2}
                 wrapper={(text: string) => (
-                  <h2 className="text-2xl color-english ion-text-center">
+                  <h2 className="text-2xl color-english margin-bottom-1 ion-text-center">
                     {text}
                   </h2>
                 )}
@@ -204,12 +204,12 @@ const Pill: (args: any) => any = ({ icon, text, value }) => {
       />
       <IonText>
         <h2 style={{ marginTop: 0 }}>
-          <span className="text-lg semibold color-suelo">{texts[0].text}</span>
+          <span className="text-xl semibold color-suelo">{texts[0].text}</span>
           {texts.length > 1 && (
-            <span className="text-lg color-english"> {texts[1].text}</span>
+            <span className="text-xl color-english"> {texts[1].text}</span>
           )}
         </h2>
-        <p className="text-sm color-english">{value}</p>
+        <p className="text-md color-english">{value}</p>
       </IonText>
     </div>
   );

--- a/packages/app/src/pages/Stories/StoriesGame.tsx
+++ b/packages/app/src/pages/Stories/StoriesGame.tsx
@@ -220,9 +220,9 @@ export const StoriesGame: React.FC<StoriesGameProps> = ({
       <div style={{ margin: "auto", textAlign: "center" }}>
         <div className="margin-top-2 margin-bottom-2 text-responsive">
           <IonText className="ion-text-center">
-            <h1 className="text-3xl color-suelo">{texts[0].text}</h1>
+            <h1 className="text-4xl color-suelo">{texts[0].text}</h1>
             {texts.length > 1 && (
-              <p className="text-xl color-english">{texts[1].text}</p>
+              <p className="text-2xl color-english">{texts[1].text}</p>
             )}
           </IonText>
         </div>

--- a/packages/app/src/pages/Stories/StoryPage.tsx
+++ b/packages/app/src/pages/Stories/StoryPage.tsx
@@ -19,15 +19,15 @@ interface Lookup {
 }
 
 const textSizePrimaryLookup: Lookup = {
-  small: "text-xl",
-  default: "text-2xl",
-  large: "text-3xl",
+  small: "text-2xl",
+  default: "text-3xl",
+  large: "text-4xl",
 };
 
 const textSizeSecondaryLookup: Lookup = {
-  small: "text-md",
-  default: "text-lg",
-  large: "text-xl",
+  small: "text-lg",
+  default: "text-2xl",
+  large: "text-3xl",
 };
 
 export const StoryPage: React.FC<React.PropsWithChildren<StoryPage>> = ({
@@ -68,6 +68,7 @@ export const StoryPage: React.FC<React.PropsWithChildren<StoryPage>> = ({
               flexDirection: "column",
               justifyContent: "space-between",
               height: "100%",
+              margin: "0.6rem",
             }}
           >
             <div></div>

--- a/packages/app/src/pages/Stories/TitleCard.tsx
+++ b/packages/app/src/pages/Stories/TitleCard.tsx
@@ -56,9 +56,9 @@ export const TitleCard = ({
               )}
               <IonCardContent>
                 <IonText className="ion-text-center title">
-                  <h1 className="text-3xl color-suelo">{titles[0].text}</h1>
+                  <h1 className="text-5xl color-suelo">{titles[0].text}</h1>
                   {titles.length > 1 && (
-                    <p className="text-xl color-english">{titles[1].text}</p>
+                    <p className="text-3xl color-english">{titles[1].text}</p>
                   )}
                 </IonText>
                 <div className="ion-text-center" style={{ width: "100%" }}>
@@ -69,7 +69,7 @@ export const TitleCard = ({
                     style={{ minWidth: "60%" }}
                   >
                     <div>
-                      <h1 className="text-2xl semibold color-nube ion-no-padding">
+                      <h1 className="text-3xl semibold color-nube ion-no-padding">
                         <I18nMessage id="story.letsRead" />
                       </h1>
                       <I18nMessage

--- a/packages/app/src/pages/Stories/VocabModal.scss
+++ b/packages/app/src/pages/Stories/VocabModal.scss
@@ -25,7 +25,7 @@
 
   &.underline {
     display: inline-block;
-    border-top: 0.5rem solid #ec59b1;
+    border-top: 0.4rem solid #ec59b1;
     border-radius: 1rem;
     width: 80%;
   }

--- a/packages/app/src/pages/Stories/VocabModal.tsx
+++ b/packages/app/src/pages/Stories/VocabModal.tsx
@@ -87,7 +87,7 @@ export const VocabModal: React.FC = () => {
                           />
                         </h1>
                         {currentWordFamily.length > 1 && (
-                          <p className="text-3xl semibold word-color">
+                          <p className="text-3xl  word-color">
                             <SyllableBreakdown
                               word={currentWordFamily[1].syllable_breakdown}
                             />
@@ -105,7 +105,7 @@ export const VocabModal: React.FC = () => {
                       </div>
 
                       <IonText>
-                        <h1 className="text-2xl semibold">
+                        <h1 className="text-2xl ">
                           {currentWordFamily[0].definition}
                         </h1>
                         {currentWordFamily.length > 1 && (


### PR DESCRIPTION
- Resized text in `KeyVocabPage`, `TitleCard`, `VocabModal`, `StoryPage`, and `StoryGame` to match Figma
- Added margin to `StoryPage`
  - Became necessary after resizing text
- Updated `textSizeLookup` sizes 