### PR TITLE
Sasha parent onboard fix

### DIFF
--- a/packages/app/src/hooks/dictionaries/en.json
+++ b/packages/app/src/hooks/dictionaries/en.json
@@ -207,6 +207,7 @@
   "signUp.teacher2": "I want to use this app with my students",
   "signUp.trialDescription": "For a limited time only",
   "signUp.trialTitle": "2 week free trial",
+  "signUpParent.betaTestersOnly": "Account creation is currently available for beta testers only. ",
   "signUpParent.classCode": "What’s your class code?",
   "signUpParent.classCodeAsk": "Don’t know your class code? Ask a teacher",
   "signUpParent.classCodeError": "Wrong class code. Try again, please!",

--- a/packages/app/src/hooks/dictionaries/es.json
+++ b/packages/app/src/hooks/dictionaries/es.json
@@ -207,6 +207,7 @@
   "signUp.teacher2": "Quiero usar esta aplicación con mis alumnos.",
   "signUp.trialDescription": "Por tiempo limitado solamente",
   "signUp.trialTitle": "Prueba gratuita de 2 semanas",
+  "signUpParent.betaTestersOnly": "Actualmente, la creación de cuentas solo está disponible para probadores beta.",
   "signUpParent.classCode": "¿Cuál es tu código de clase?",
   "signUpParent.classCodeAsk": "¿No sabes tu código de clase? Pregúntale a un maestro.",
   "signUpParent.classCodeError": "Código de clase incorrecto. ¡Intentar otra vez!",

--- a/packages/app/src/pages/SignUp/ClassCode.tsx
+++ b/packages/app/src/pages/SignUp/ClassCode.tsx
@@ -128,6 +128,14 @@ export const ClassCode: React.FC = () => {
                       />
                     </p>
                   </IonText>
+                  <IonText color="danger" className="ion-text-center">
+                    <p>
+                      <I18nMessage
+                        id="signUpParent.betaTestersOnly"
+                        languageSource="unauthed"
+                      />
+                    </p>
+                  </IonText>
                 </IonCardTitle>
               </IonCardHeader>
               <IonCardContent>

--- a/packages/app/src/pages/Splash.tsx
+++ b/packages/app/src/pages/Splash.tsx
@@ -39,14 +39,14 @@ export const Splash: React.FC = () => {
             </IonCardContent>
           </IonCard>
 
-          <IonCard>
+          {/* TEMPORARY HIDDEN WAITLIST CARD */}
+          {/* <IonCard>
             <IonCardContent>
               <IonCardTitle className={titleClasses}>
                 <I18nMessage id="splash.newAccount" languageSource="unauthed" />
               </IonCardTitle>
               <Link to="/waitlist" className="no-underline">
                 <IonButton expand="block" fill="outline" shape="round">
-                  {/*<I18nMessage id="splash.createAccountButton" languageSource='unauthed' />*/}
                   <I18nMessage
                     id="splash.joinWaitlist"
                     languageSource="unauthed"
@@ -54,14 +54,14 @@ export const Splash: React.FC = () => {
                 </IonButton>
               </Link>
             </IonCardContent>
-          </IonCard>
+          </IonCard> */}
 
           <IonCard>
             <IonCardContent>
               <IonCardTitle className={titleClasses}>
                 <I18nMessage id="splash.classCode" languageSource="unauthed" />
               </IonCardTitle>
-              <Link to="/quicklaunch" className="no-underline">
+              <Link to="/sign-up/by-class-code" className="no-underline">
                 <IonButton expand="block" fill="outline" shape="round">
                   <I18nMessage
                     id="splash.classCodeButton"


### PR DESCRIPTION
- `Join the waitlist` card is hidden now.
- After clicking `Enter the classroom code` it goes now to the `sign-up/by-class-code`.
- Multilanguage text was added to the `ClassCode` page to let users know that it's `beta testers only`.