### PR TITLE
Sasha sf game update

### DIFF
--- a/packages/app/src/pages/StoryFactory/EarlyReader.tsx
+++ b/packages/app/src/pages/StoryFactory/EarlyReader.tsx
@@ -37,7 +37,6 @@ function shuffleArray(array: any[]) {
 }
 
 const getText = (word: any, language: string) => {
-  console.log(word, language);
   return word.filter((w: any) => w.language === language)[0].text;
 };
 
@@ -50,6 +49,7 @@ const generateSVG = (color: string, direction: string) => {
         height="32"
         viewBox="0 0 55 32"
         fill="none"
+        style={{ width: "100%" }}
       >
         <path
           d="M24.9332 1.61877C26.3424 0.181033 28.6576 0.181035 30.0668 1.61878L53.1212 25.14C55.3504 27.4144 53.7391 31.25 50.5544 31.25L4.44562 31.25C1.26091 31.25 -0.35043 27.4144 1.87882 25.14L24.9332 1.61877Z"
@@ -65,6 +65,7 @@ const generateSVG = (color: string, direction: string) => {
         height="32"
         viewBox="0 0 55 32"
         fill="none"
+        style={{ width: "100%" }}
       >
         <path
           d="M30.0668 30.5062C28.6576 31.944 26.3424 31.944 24.9332 30.5062L1.87882 6.98501C-0.35043 4.71062 1.26091 0.875 4.44562 0.875L50.5544 0.875003C53.7391 0.875003 55.3504 4.71063 53.1212 6.98502L30.0668 30.5062Z"
@@ -189,6 +190,7 @@ export const StoryFactoryEarlyReader: React.FC = () => {
               (color, index) => (
                 <IonCol key={index}>
                   <span
+                    style={{ display: "inline-block", width: "5rem" }}
                     onClick={() => {
                       handleUpArrowClick(index);
                     }}
@@ -277,6 +279,7 @@ export const StoryFactoryEarlyReader: React.FC = () => {
               (color, index) => (
                 <IonCol key={index}>
                   <span
+                    style={{ display: "inline-block", width: "5rem" }}
                     onClick={() => {
                       handleDownArrowClick(index);
                     }}

--- a/packages/app/src/pages/StoryFactory/EarlyReader.tsx
+++ b/packages/app/src/pages/StoryFactory/EarlyReader.tsx
@@ -10,6 +10,7 @@ import { FirestoreDocProvider, useFirestoreDoc } from "@/hooks/FirestoreDoc";
 
 import "./StoryFactory.scss";
 import dataRaw from "./EarlyReaderData.json";
+import { useLanguage } from "@/hooks/Language";
 
 const AWS_BUCKET =
   "https://bili-strapi-media-dev.s3.amazonaws.com/story_factory/"; // todo: don't hardcode
@@ -36,6 +37,7 @@ function shuffleArray(array: any[]) {
 }
 
 const getText = (word: any, language: string) => {
+  console.log(word, language);
   return word.filter((w: any) => w.language === language)[0].text;
 };
 
@@ -74,7 +76,7 @@ const generateSVG = (color: string, direction: string) => {
 };
 
 export const StoryFactoryEarlyReader: React.FC = () => {
-  const { language } = useLanguageToggle();
+  const { language } = useLanguage();
   const { addAudio, clearAudio, onended } = useAudioManager();
   //const { status, data } = useFirestoreDoc();
   const status: string = "ready";
@@ -208,7 +210,7 @@ export const StoryFactoryEarlyReader: React.FC = () => {
                       ? getText(words[0][wordIndices[0]].word, "en")
                       : getText(words[0][wordIndices[0]].word, "es")}
                   </h1>
-                  {language === "esen" && (
+                  {language === "es.en" && (
                     <p className="text-3xl color-english">
                       {getText(words[0][wordIndices[0]].word, "en")}
                     </p>
@@ -225,7 +227,7 @@ export const StoryFactoryEarlyReader: React.FC = () => {
                       ? getText(words[1][wordIndices[1]].word, "en")
                       : getText(words[1][wordIndices[1]].word, "es")}
                   </h1>
-                  {language === "esen" && (
+                  {language === "es.en" && (
                     <p className="text-3xl color-english">
                       {getText(words[1][wordIndices[1]].word, "en")}
                     </p>
@@ -242,7 +244,7 @@ export const StoryFactoryEarlyReader: React.FC = () => {
                       ? getText(words[2][wordIndices[2]].word, "en")
                       : getText(words[2][wordIndices[2]].word, "es")}
                   </h1>
-                  {language === "esen" && (
+                  {language === "es.en" && (
                     <p className="text-3xl color-english">
                       {getText(words[2][wordIndices[2]].word, "en")}
                     </p>
@@ -259,7 +261,7 @@ export const StoryFactoryEarlyReader: React.FC = () => {
                       ? getText(words[3][wordIndices[3]].word, "en")
                       : getText(words[3][wordIndices[3]].word, "es")}
                   </h1>
-                  {language === "esen" && (
+                  {language === "es.en" && (
                     <p className="text-3xl color-english">
                       {getText(words[3][wordIndices[3]].word, "en")}
                     </p>

--- a/packages/app/src/pages/StoryFactory/StoryFactory.scss
+++ b/packages/app/src/pages/StoryFactory/StoryFactory.scss
@@ -605,18 +605,10 @@ ion-card.new-felicitaciones-card {
   letter-spacing: -0.0660625rem;
   padding: 0.3125rem 0 0.3125rem;
   white-space: pre;
+  margin-bottom: 3rem;
 
-  @media screen and (max-width: 768px) {
-    font-size: 4.5rem;
-    //margin-bottom: 1rem;
-  }
-
-  @media screen and (max-width: 480px) {
-    font-size: 4rem;
-  }
-
-  @media screen and (max-width: 430px) {
-    font-size: 2.5rem;
+  @media screen and (max-width: 932px) {
+    margin-bottom: 0px;
   }
 }
 

--- a/packages/app/src/pages/StoryFactory/StoryFactory.scss
+++ b/packages/app/src/pages/StoryFactory/StoryFactory.scss
@@ -604,12 +604,11 @@ ion-card.new-felicitaciones-card {
   font-weight: 700;
   letter-spacing: -0.0660625rem;
   padding: 0.3125rem 0 0.3125rem;
-  // margin: 5% 5% 7%;
   white-space: pre;
 
   @media screen and (max-width: 768px) {
     font-size: 4.5rem;
-    margin-bottom: 5%;
+    //margin-bottom: 1rem;
   }
 
   @media screen and (max-width: 480px) {
@@ -684,7 +683,7 @@ ion-card.new-felicitaciones-card {
   position: relative;
   z-index: 2;
   width: 100%;
-  height: 62.5rem;
+  //height: 62.5rem;
 }
 
 .option-orange {

--- a/packages/app/src/pages/StoryFactory/StoryFactoryLevel1.tsx
+++ b/packages/app/src/pages/StoryFactory/StoryFactoryLevel1.tsx
@@ -66,7 +66,7 @@ const WrappedSF1: React.FC = () => {
       case "en":
         return g.language.includes("en");
         break;
-      case "esen":
+      case "es.en":
         // TODO: check if inclusive also
         return g.language.includes("en") && g.language.includes("es");
       default:


### PR DESCRIPTION
- Updated language for Bilingual mode
- Updated arrow size for the smaller screens and set their `width` to `5rem`
- Removed margin-bottom for smaller screens for Fabrica the Cuentos text
- Removed `height` from the `.sf-game-content` class