### PR TITLE
Cuentos Line Breaks

### DIFF
--- a/packages/app/src/pages/Stories/StoryPage.tsx
+++ b/packages/app/src/pages/Stories/StoryPage.tsx
@@ -79,7 +79,7 @@ export const StoryPage: React.FC<React.PropsWithChildren<StoryPage>> = ({
                   <p
                     key={`primary-${i}`}
                     className={classnames(
-                      "semibold color-suelo",
+                      "semibold color-suelo margin-vertical-1",
                       textSizePrimaryLookup[textSize],
                     )}
                   >
@@ -93,7 +93,7 @@ export const StoryPage: React.FC<React.PropsWithChildren<StoryPage>> = ({
                     <p
                       key={`secondary-${i}`}
                       className={classnames(
-                        "color-english",
+                        "color-english margin-top-0-5",
                         textSizeSecondaryLookup[textSize],
                       )}
                     >

--- a/packages/app/src/pages/Stories/StoryPage.tsx
+++ b/packages/app/src/pages/Stories/StoryPage.tsx
@@ -19,15 +19,15 @@ interface Lookup {
 }
 
 const textSizePrimaryLookup: Lookup = {
-  small: "text-2xl",
-  default: "text-3xl",
-  large: "text-4xl",
+  small: "text-2xl margin-vertical-1",
+  default: "text-3xl margin-vertical-2",
+  large: "text-4xl margin-vertical-3",
 };
 
 const textSizeSecondaryLookup: Lookup = {
-  small: "text-lg",
-  default: "text-2xl",
-  large: "text-3xl",
+  small: "text-lg margin-top-0-5",
+  default: "text-2xl margin-top-1",
+  large: "text-3xl margin-top-1-5",
 };
 
 export const StoryPage: React.FC<React.PropsWithChildren<StoryPage>> = ({
@@ -79,7 +79,7 @@ export const StoryPage: React.FC<React.PropsWithChildren<StoryPage>> = ({
                   <p
                     key={`primary-${i}`}
                     className={classnames(
-                      "semibold color-suelo margin-vertical-1",
+                      "semibold color-suelo ",
                       textSizePrimaryLookup[textSize],
                     )}
                   >

--- a/packages/app/src/pages/Stories/StoryPage.tsx
+++ b/packages/app/src/pages/Stories/StoryPage.tsx
@@ -73,24 +73,33 @@ export const StoryPage: React.FC<React.PropsWithChildren<StoryPage>> = ({
           >
             <div></div>
             <IonText className="ion-text-center">
-              <h1
-                className={classnames(
-                  "semibold color-suelo",
-                  textSizePrimaryLookup[textSize],
-                )}
-              >
-                <SegmentedText text={texts[0].text} />
-              </h1>
-              {texts.length > 1 && (
-                <p
-                  className={classnames(
-                    "color-english",
-                    textSizeSecondaryLookup[textSize],
-                  )}
-                >
-                  <SegmentedText text={texts[1].text} />
-                </p>
-              )}
+              {texts[0].text
+                .split(/\n+/)
+                .map((paragraph: string, i: number) => (
+                  <p
+                    key={`primary-${i}`}
+                    className={classnames(
+                      "semibold color-suelo",
+                      textSizePrimaryLookup[textSize],
+                    )}
+                  >
+                    <SegmentedText text={paragraph} />
+                  </p>
+                ))}
+              {texts.length > 1 &&
+                texts[1].text
+                  .split(/\n+/)
+                  .map((paragraph: string, i: number) => (
+                    <p
+                      key={`secondary-${i}`}
+                      className={classnames(
+                        "color-english",
+                        textSizeSecondaryLookup[textSize],
+                      )}
+                    >
+                      <SegmentedText text={paragraph} />
+                    </p>
+                  ))}
             </IonText>
             <div>
               <AudioButton

--- a/packages/app/src/theme/margin-classes.scss
+++ b/packages/app/src/theme/margin-classes.scss
@@ -3,6 +3,10 @@
   margin-right: 1.875rem;
 }
 
+.margin-top-0-5 {
+  margin-top: 0.5rem !important;
+}
+
 @for $margin from 1 through 5 {
   .margin-top-#{$margin} {
     margin-top: #{$margin}rem !important;


### PR DESCRIPTION
Cuentos text gets split on newline characters. Each line is mapped to a `<p>` tag. 

**Original**
<img width="1512" alt="Screenshot 2025-05-02 at 1 31 39 PM" src="https://github.com/user-attachments/assets/bd2bf1eb-1857-44bd-b51e-fd006a7c4591" />

**With newline**
<img width="1512" alt="Screenshot 2025-05-02 at 1 28 13 PM" src="https://github.com/user-attachments/assets/2446d5fd-99c1-42c0-a260-7d436a961fb8" />

**With margin**
<img width="1512" alt="Screenshot 2025-05-02 at 1 29 44 PM" src="https://github.com/user-attachments/assets/2b3a80f6-e74f-4c08-bfe0-7392a7fb22bc" />

