### PR TITLE
Reposition Audio Button

### DIFF
--- a/packages/app/src/pages/Stories/PageWrapper.tsx
+++ b/packages/app/src/pages/Stories/PageWrapper.tsx
@@ -66,7 +66,7 @@ export const PageWrapper: React.FC<React.PropsWithChildren> = ({
         <div
           style={{
             position: "fixed",
-            bottom: "1.5rem",
+            bottom: "2.75rem",
             right: "1.5rem",
             zIndex: 9999,
           }}

--- a/packages/app/src/pages/Stories/PageWrapper.tsx
+++ b/packages/app/src/pages/Stories/PageWrapper.tsx
@@ -1,22 +1,53 @@
 // TODO: replace page controls with already existing PageControl component
 
+import React, { useState } from "react";
+import { ReactElement } from "react";
 import classnames from "classnames";
-import { IonCol, IonGrid, IonRow, IonImg } from "@ionic/react";
+import { IonGrid, IonRow, IonImg } from "@ionic/react";
 import { useStory } from "./StoryContext";
+import { AudioButton } from "@/components/AudioButton";
 
 import forward from "@/assets/icons/carousel_forward.svg";
 import backward from "@/assets/icons/carousel_backward.svg";
+
+interface StoryPageProps {
+  page: any;
+  languages: any[];
+  textSize: string;
+  onAudioReady?: (audio: Record<string, string>) => void;
+}
 
 export const PageWrapper: React.FC<React.PropsWithChildren> = ({
   children,
 }) => {
   const { pageBackward, pageForward, pageNumber, pages, pageLocks } =
     useStory();
+  const [audioMap, setAudioMap] = useState<Record<string, string>>({});
+
+  if (!pages || !pages.length || !pages[pageNumber]) {
+    return <>{children}</>;
+  }
+
+  const wrappedChildren = React.Children.map(children, (child) => {
+    if (!React.isValidElement(child)) return child;
+    const maybeStoryPage = child as ReactElement<StoryPageProps>;
+    if (maybeStoryPage.props.page == null) {
+      return child;
+    }
+    return React.cloneElement<StoryPageProps>(maybeStoryPage, {
+      onAudioReady: (map) => setAudioMap(map),
+    });
+  });
+
   const totalPages = pages.length;
+
   return (
-    <div className="content-wrapper story-pages-wrapper">
+    <div
+      className="content-wrapper story-pages-wrapper"
+      style={{ position: "relative" }}
+    >
       <IonGrid>
-        <IonRow>{children}</IonRow>
+        <IonRow>{wrappedChildren}</IonRow>
       </IonGrid>
       <IonImg
         className="page-control backward"
@@ -31,6 +62,18 @@ export const PageWrapper: React.FC<React.PropsWithChildren> = ({
         onClick={pageForward}
         style={{ opacity: pageNumber === totalPages - 1 ? 0 : 1 }}
       />
+      {Object.keys(audioMap).length > 0 && (
+        <div
+          style={{
+            position: "fixed",
+            bottom: "1.5rem",
+            right: "1.5rem",
+            zIndex: 9999,
+          }}
+        >
+          <AudioButton audio={audioMap} size="large" />
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/app/src/pages/Stories/StoryPage.tsx
+++ b/packages/app/src/pages/Stories/StoryPage.tsx
@@ -12,6 +12,7 @@ interface StoryPage {
   languages: any[];
   page: any;
   textSize: string;
+  onAudioReady?: (audio: Record<string, string>) => void;
 }
 
 interface Lookup {
@@ -34,26 +35,41 @@ export const StoryPage: React.FC<React.PropsWithChildren<StoryPage>> = ({
   languages,
   page,
   textSize,
+  onAudioReady,
 }) => {
   const { isTranslanguaged, pageNumber, pages, pageForward, pageBackward } =
     useStory();
   const { clearAudio } = useAudioManager();
   const { filterText, languageNormalized } = useLanguage();
+
   if (!languages.includes(languageNormalized)) {
     pageBackward();
   }
+
   useEffect(() => {
     return clearAudio;
   }, []);
   useEffect(() => {
     clearAudio();
   }, [pageNumber]);
+
   const texts = isTranslanguaged
     ? [filterText(page.text)[0]]
     : filterText(page.text);
+
+  useEffect(() => {
+    if (onAudioReady && texts.length) {
+      const map = Object.fromEntries(
+        texts.map((t: any) => [t.language, t.audio.url]),
+      );
+      onAudioReady(map);
+    }
+  }, [texts, onAudioReady]);
+
   if (texts.length === 0) {
     return <></>;
   }
+
   return (
     <>
       <IonCol size="6">
@@ -93,11 +109,13 @@ export const StoryPage: React.FC<React.PropsWithChildren<StoryPage>> = ({
               )}
             </IonText>
             <div>
+              {/*
               <AudioButton
                 audio={Object.fromEntries(
                   texts.map((t: any) => [t.language, t.audio.url]),
                 )}
               />
+              */}
             </div>
           </IonCardContent>
         </IonCard>


### PR DESCRIPTION
Moved audio button from the story page card to bottom right of screen
- Removed the `AudioButton` block from `StoryPage` and placed in `PageWrapper` with fixed positioning -- aligned to language toggle
- Added callback prop to `StoryPage` to pass the audio map to `PageWrapper`
- 
![Screenshot 2025-05-14 at 4 54 42 PM](https://github.com/user-attachments/assets/ac94835a-3268-4081-8874-dddcceb910ad)
