### PR TITLE
New Cuentos Header

### DIFF
--- a/packages/app/src/components/HeaderFooter/StoryHeaderFooter.scss
+++ b/packages/app/src/components/HeaderFooter/StoryHeaderFooter.scss
@@ -1,0 +1,27 @@
+#authedHeader {
+  padding-top: 1rem;
+  background-color: #fff;
+  ion-col {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+}
+
+.story-header {
+  position: absolute;
+  left: 0;
+  right: 0;
+  padding: 0.7rem 0.34rem;
+}
+
+.story-content {
+  padding-top: var(--header-height);
+}
+
+.profile-chip-container {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  top: -0.25rem;
+  left: -1rem;
+}

--- a/packages/app/src/components/HeaderFooter/StoryHeaderFooter.tsx
+++ b/packages/app/src/components/HeaderFooter/StoryHeaderFooter.tsx
@@ -1,0 +1,24 @@
+import { IonGrid, IonRow, IonCol, IonPage, IonContent } from "@ionic/react";
+import { BackButton } from "@/components/BackButton";
+import { ProfileChip } from "@/components/ProfileChip";
+import "./StoryHeaderFooter.scss";
+
+export const StoryHeaderFooter: React.FC<React.PropsWithChildren<{}>> = ({
+  children,
+}) => (
+  <IonPage>
+    <IonContent fullscreen className="story-page-wrapper">
+      <IonGrid className="story-header">
+        <IonRow className="ion-align-items-center ion-justify-content-between">
+          <IonCol size="auto">
+            <BackButton />
+          </IonCol>
+          <IonCol size="auto" className="profile-chip-container">
+            <ProfileChip size="minimal" />
+          </IonCol>
+        </IonRow>
+      </IonGrid>
+      <div className="story-content">{children}</div>
+    </IonContent>
+  </IonPage>
+);

--- a/packages/app/src/components/ProfileChip/ProfileChip.scss
+++ b/packages/app/src/components/ProfileChip/ProfileChip.scss
@@ -52,3 +52,20 @@ ion-popover.profile-popover-style {
   --offset-x: -1rem;
   --offset-y: 0.625rem;
 }
+
+#profileChip.profile-chip--minimal {
+  background-color: transparent !important;
+}
+
+.profile-chip--minimal #starPoints {
+  margin: 0 0.5rem !important;
+  border-radius: 2rem !important;
+  padding: 0.25rem 0.625rem !important;
+  color: white !important;
+}
+
+.profile-chip--minimal #heartPoints {
+  margin: 0 !important;
+  border-radius: 2rem !important;
+  padding: 0.25rem 0.625rem !important;
+}

--- a/packages/app/src/components/ProfileChip/ProfileChip.tsx
+++ b/packages/app/src/components/ProfileChip/ProfileChip.tsx
@@ -37,16 +37,28 @@ interface ProfileChipPopoverLink {
   url: string;
 }
 
-export const ProfileChip: React.FC = () => {
+interface ProfileChipProps {
+  size?: "default" | "minimal";
+}
+
+export const ProfileChip: React.FC<ProfileChipProps> = ({
+  size = "default",
+}) => {
   const { id } = useStudent();
   return (
     <RealtimeDatabaseDocProvider path={`/users/${id}`}>
-      <HydratedProfileChip />
+      <HydratedProfileChip size={size} />
     </RealtimeDatabaseDocProvider>
   );
 };
 
-const HydratedProfileChip: React.FC = () => {
+interface HydratedProfileChipProps {
+  size?: "default" | "minimal";
+}
+
+const HydratedProfileChip: React.FC<HydratedProfileChipProps> = ({
+  size = "default",
+}) => {
   const { firstName, id, signOut: signStudentOut } = useStudent();
   const history = useHistory();
   const { pathname } = useLocation();
@@ -92,11 +104,14 @@ const HydratedProfileChip: React.FC = () => {
     <>
       <div>
         <button
-          onClick={openPopover}
+          onClick={size === "default" ? openPopover : undefined}
           className="custom-button-color"
           id="top-center"
         >
-          <div id="profileChip">
+          <div
+            id="profileChip"
+            className={size === "minimal" ? "profile-chip--minimal" : ""}
+          >
             <div id="starPoints" className="text-sm semibold color-nube">
               <IonIcon icon={StarNotSharp} />
               <IonText>
@@ -109,41 +124,74 @@ const HydratedProfileChip: React.FC = () => {
                 {status === "ready" ? data?.totalHearts ?? 0 : "\u00A0"}
               </IonText>
             </div>
-            <IonText>
-              <p className="semibold color-suelo text-xl">{firstName}</p>
-            </IonText>
-            <Avatar id={id} size="md" />
+            {size === "default" && (
+              <>
+                <IonText>
+                  <p className="semibold color-suelo text-xl">{firstName}</p>
+                </IonText>
+                <Avatar id={id} size="md" />
+              </>
+            )}
           </div>
         </button>
       </div>
 
-      <IonPopover
-        ref={popover}
-        isOpen={popoverOpen}
-        onDidDismiss={() => setPopoverOpen(false)}
-        size="auto"
-        side="bottom"
-        alignment="end"
-        trigger="top-center"
-        arrow={false}
-        className="profile-popover-style"
-      >
-        <IonContent id="profile-chip-popover" forceOverscroll={false}>
-          {links.map((l: ProfileChipPopoverLink) => (
-            <Link
-              className="no-underline"
-              key={l.i18nId}
-              onClick={() => {
-                setPopoverOpen(false);
-              }}
-              to={l.url}
-            >
-              <IonButton expand="block" fill="clear">
-                <IonIcon icon={l.icon} slot="start" />
+      {size === "default" && (
+        <IonPopover
+          ref={popover}
+          isOpen={popoverOpen}
+          onDidDismiss={() => setPopoverOpen(false)}
+          size="auto"
+          side="bottom"
+          alignment="end"
+          trigger="top-center"
+          arrow={false}
+          className="profile-popover-style"
+        >
+          <IonContent id="profile-chip-popover" forceOverscroll={false}>
+            {links.map((l: ProfileChipPopoverLink) => (
+              <Link
+                className="no-underline"
+                key={l.i18nId}
+                onClick={() => {
+                  setPopoverOpen(false);
+                }}
+                to={l.url}
+              >
+                <IonButton expand="block" fill="clear">
+                  <IonIcon icon={l.icon} slot="start" />
+                  <IonText className="ion-text-left color-suelo text-md">
+                    <I18nMessage id={l.i18nId} />
+                    <I18nMessage
+                      id={l.i18nId}
+                      level={2}
+                      wrapper={(text: string) => (
+                        <p className="text-sm">{text}</p>
+                      )}
+                    />
+                  </IonText>
+                </IonButton>
+              </Link>
+            ))}
+            {pathname.startsWith("/classroom/student-select") && (
+              <IonButton
+                expand="block"
+                fill="clear"
+                onClick={() => {
+                  signStudentOut();
+                  signUserOut();
+                  signClassroomOut();
+                  history.replace("/");
+                  // user sign out
+                  // student sign out
+                  // classroom sign out
+                  // redirect to /
+                }}
+              >
                 <IonText className="ion-text-left color-suelo text-md">
-                  <I18nMessage id={l.i18nId} />
+                  <I18nMessage id="common.logOut" />
                   <I18nMessage
-                    id={l.i18nId}
+                    id="common.logOut"
                     level={2}
                     wrapper={(text: string) => (
                       <p className="text-sm">{text}</p>
@@ -151,35 +199,10 @@ const HydratedProfileChip: React.FC = () => {
                   />
                 </IonText>
               </IonButton>
-            </Link>
-          ))}
-          {pathname.startsWith("/classroom/student-select") && (
-            <IonButton
-              expand="block"
-              fill="clear"
-              onClick={() => {
-                signStudentOut();
-                signUserOut();
-                signClassroomOut();
-                history.replace("/");
-                // user sign out
-                // student sign out
-                // classroom sign out
-                // redirect to /
-              }}
-            >
-              <IonText className="ion-text-left color-suelo text-md">
-                <I18nMessage id="common.logOut" />
-                <I18nMessage
-                  id="common.logOut"
-                  level={2}
-                  wrapper={(text: string) => <p className="text-sm">{text}</p>}
-                />
-              </IonText>
-            </IonButton>
-          )}
-        </IonContent>
-      </IonPopover>
+            )}
+          </IonContent>
+        </IonPopover>
+      )}
     </>
   );
 };

--- a/packages/app/src/components/Router/Router.tsx
+++ b/packages/app/src/components/Router/Router.tsx
@@ -202,7 +202,7 @@ export const Router: React.FC = () => {
             </StudentLayout>
           </Route>
           <Route exact path="/story/play/:uuid">
-            <StudentLayout>
+            <StudentLayout headerSize="minimal">
               <Stories />
             </StudentLayout>
           </Route>

--- a/packages/app/src/layouts/Student.tsx
+++ b/packages/app/src/layouts/Student.tsx
@@ -1,4 +1,5 @@
 import { HeaderFooter } from "@/components/HeaderFooter";
+import { StoryHeaderFooter } from "@/components/HeaderFooter/StoryHeaderFooter";
 import { I18nWrapper } from "@/components/I18nWrapper";
 import {
   LanguageToggle,
@@ -9,26 +10,30 @@ import { useClassroom } from "@/hooks/Classroom";
 import { useLanguage } from "@/hooks/Language";
 import { useStudent } from "@/hooks/Student";
 
-export const StudentLayout: React.FC<React.PropsWithChildren> = ({
-  children,
-}) => {
+type HeaderSize = "default" | "minimal";
+
+export const StudentLayout: React.FC<
+  React.PropsWithChildren<{ headerSize?: HeaderSize }>
+> = ({ children, headerSize = "default" }) => {
   const { info: classroomInfo } = useClassroom();
   const { isLoggedIn, signOut } = useStudent();
   const { language } = useLanguage();
 
   /*
-  if (!classroomInfo) {
-    signOut();
-    // how can be student if no info?
-    return <Redirect to="/" />;
-  }
-  */
+    if (!classroomInfo) {
+      signOut();
+      // how can be student if no info?
+      return <Redirect to="/" />;
+    }
+    */
 
   // TODO: pull allowedLanguages from caregiver
 
   if (!isLoggedIn) {
     return <Redirect to="/" />;
   }
+
+  const Wrapper = headerSize === "minimal" ? StoryHeaderFooter : HeaderFooter;
 
   return (
     <I18nWrapper locale={language.slice(0, 2)}>
@@ -37,10 +42,11 @@ export const StudentLayout: React.FC<React.PropsWithChildren> = ({
           classroomInfo?.allowedLanguages ?? ["es", "en", "es.en"]
         }
       >
-        <HeaderFooter>
+        <Wrapper>
           {children}
+          {headerSize === "default"}
           {(classroomInfo?.allowLanguageToggle ?? true) && <LanguageToggle />}
-        </HeaderFooter>
+        </Wrapper>
       </LanguageToggleProvider>
     </I18nWrapper>
   );


### PR DESCRIPTION
- Updated `ProfileChip` to take a `size` prop. 
  - `size === 'minimal'` hides name and avatar and disables the dropdown menu
  - `size === 'default'` is the original profile chip
- `StoryHeaderFooter` builds the header for stories only
- `layouts/Student.tsx` takes a `headerSize` prop and chooses between the original `headerFooter` or `StoryHeaderFooter`
- Passed `headerSize="minimal"` to `story/play/:uuid` in `Router` to show minimal header on story pages

<img width="1058" alt="Screenshot 2025-05-19 at 4 25 12 PM" src="https://github.com/user-attachments/assets/7213213a-29ec-4c2c-8004-65a14101ba4e" />
